### PR TITLE
Refactor NPC cheering to cached system and add double cheer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 *   GM debug commands for resetting player status and testing the trial.
 *   Fully configurable via `mod_trial_of_finality.conf`.
 *   Designed to be compatible with `mod-playerbots` (bots are excluded from participating).
+*   **Dynamic NPC Cheering (Cached):** Upon successful trial completion, NPCs in configured major cities can perform cheers for the victorious players. This system uses a server-startup cache of eligible NPCs to ensure minimal performance impact. The system is designed to make NPCs cheer twice, though the second cheer's delayed execution is currently logged pending further implementation of core timer functionalities.
 
 ## 3. Installation
 
@@ -57,6 +58,21 @@ Key configuration options (see the `.conf` file for default values and comments)
 *   `TrialOfFinality.NpcScaling.Mode`: (Currently "match_highest_level", future expansion possible).
 *   `TrialOfFinality.DisableCharacter.Method`: (Currently "custom_flag" via Aura ID `40000`. Future DB flag possible).
 *   `TrialOfFinality.GMDebug.Enable`: (Not currently used to gate GM commands, they are available if module is enabled).
+*   `TrialOfFinality.AnnounceWinners.World.Enable`: (true/false) Enables or disables world announcements upon successful trial completion. Default: `true`.
+*   `TrialOfFinality.AnnounceWinners.World.MessageFormat`: String format for the world announcement. Placeholders: `{group_leader}`, `{player_list}`.
+
+### NPC Cheering Settings
+
+These settings control the behavior of NPCs cheering in cities when a trial is successfully completed. This feature uses a cached list of NPCs generated at server startup.
+
+*   `TrialOfFinality.CheeringNpcs.Enable`: (true/false) Enables or disables the NPC cheering feature. Default: `true`.
+*   `TrialOfFinality.CheeringNpcs.CityZoneIDs`: Comma-separated string of Zone IDs where NPCs are eligible to cheer. Example: `"1519,1537"` for Stormwind and Orgrimmar. Default: (common city zones as per conf file).
+*   `TrialOfFinality.CheeringNpcs.RadiusAroundPlayer`: Float value defining the radius (in yards) around a player (who was part of the winning group and is in a cheering zone) within which cached NPCs will be selected to cheer. Default: `40.0`.
+*   `TrialOfFinality.CheeringNpcs.MaxNpcsToCheerPerPlayerCluster`: Integer defining the maximum number of NPCs that will cheer around a single player or a close cluster of players. Default: `5`.
+*   `TrialOfFinality.CheeringNpcs.MaxTotalNpcsToCheerWorld`: Integer defining the overall maximum number of NPCs that will cheer across the entire world for a single trial success event. Default: `50`.
+*   `TrialOfFinality.CheeringNpcs.TargetNpcFlags`: Uint32 value. NPCs must have at least one of these flags to be considered for cheering. Set to `0` (UNIT_NPC_FLAG_NONE) to target NPCs regardless of their specific flags (unless excluded). Refer to core documentation for NPC flag values. Default: `0`.
+*   `TrialOfFinality.CheeringNpcs.ExcludeNpcFlags`: Uint32 value. NPCs with any of these flags will be excluded from cheering, even if they match `TargetNpcFlags`. This is useful for preventing guards, vendors, trainers, etc., from cheering. Default: (flags for common utility NPCs, see conf file).
+*   `TrialOfFinality.CheeringNpcs.CheerIntervalMs`: Uint32 value. The intended interval in milliseconds for a second cheer from the same NPC. A value of `0` disables the second cheer. *Note: Currently, the execution of this second cheer is logged, and its full implementation depends on future enhancements to timer mechanisms.* Default: `2000`.
 
 Placeholder Aura ID for Perma-Death: `AURA_ID_TRIAL_PERMADEATH = 40000`. Ensure this aura ID is a passive, persistent aura in your DBCs, or change it to one that is.
 
@@ -139,5 +155,5 @@ Access to commands requires `SEC_GAMEMASTER` level.
 *   Creature entries for waves (`70001`-`70030`) are placeholders. Update these in `src/mod_trial_of_finality.cpp` or create these custom NPCs.
 *   Wave difficulty scaling currently adjusts NPC count and provides a basic health multiplier for later waves. More complex stat scaling or varied NPC abilities per wave could be added.
 *   Consider randomizing NPC types for waves from predefined lists to enhance replayability.
-*   World announcements for trial winners could be a future addition.
+*   World announcements for trial winners have been added (see configuration options).
 ```

--- a/conf/mod_trial_of_finality.conf
+++ b/conf/mod_trial_of_finality.conf
@@ -24,3 +24,52 @@ NpcScaling.Mode = "match_highest_level" # Options: "match_highest_level", "custo
 DisableCharacter.Method = "custom_flag" # Options: "custom_flag", "player_field_hack" (the honorable kills example)
 # GM Debugging
 GMDebug.Enable = false
+
+# --- World Announcement Settings (Step 14b) ---
+# Enable/disable world announcements upon successful trial completion.
+TrialOfFinality.AnnounceWinners.World.Enable = true
+
+# Message format for world announcements. Placeholders: {group_leader}, {player_list}
+# Example: "Hark, heroes! {group_leader} and their loyal companions {player_list} have conquered the Trial of Finality!"
+TrialOfFinality.AnnounceWinners.World.MessageFormat = "Hark, heroes! The group led by {group_leader}, with valiant trialists {player_list}, has vanquished all foes and emerged victorious from the Trial of Finality! All hail the Conquerors!"
+
+# --- Cheering NPCs Settings (Step 15b/c) ---
+# Enable/disable the NPC cheering feature upon successful trial completion.
+TrialOfFinality.CheeringNpcs.Enable = true
+
+# Comma-separated list of Zone IDs where NPCs can cheer.
+# Example: 1519 (Stormwind), 1537 (Orgrimmar), 1637 (Ironforge), 1638 (Undercity), etc.
+TrialOfFinality.CheeringNpcs.CityZoneIDs = "1519,1537,1637,1638,1657,3487,4080,4395,3557"
+
+# Radius around each player (in cheering zones) to look for NPCs to cheer.
+TrialOfFinality.CheeringNpcs.RadiusAroundPlayer = 40.0
+
+# Maximum number of NPCs that will be made to cheer around a single player or cluster of players.
+TrialOfFinality.CheeringNpcs.MaxNpcsToCheerPerPlayerCluster = 5
+
+# Overall maximum number of NPCs that will cheer across the entire world for a single trial success event.
+TrialOfFinality.CheeringNpcs.MaxTotalNpcsToCheerWorld = 50
+
+# NPC flags to target for cheering. Only NPCs with AT LEAST ONE of these flags will cheer.
+# Set to 0 (UNIT_NPC_FLAG_NONE) to allow any NPC (not specifically excluded) to cheer.
+# Example: To target only QuestGivers and Gossipers: (1 | 2) = 3 (binary OR)
+# Common Flags: NONE (0), GOSSIP (1), QUESTGIVER (2), TRAINER (4), VENDOR (8), REPAIR (16) etc.
+TrialOfFinality.CheeringNpcs.TargetNpcFlags = 0
+
+# NPC flags to exclude from cheering. NPCs with ANY of these flags will NOT cheer, even if targeted.
+# Default excludes common functional NPCs.
+# Example: (8 | 4 | 128 | etc) - VENDOR | TRAINER | AUCTIONEER
+# Default value 49148 corresponds to:
+# VENDOR (8), TRAINER (4), FLIGHTMASTER (32), REPAIR (16), AUCTIONEER (128), BANKER (256),
+# TABARDDESIGNER (1024), STABLEMASTER (4096), GUILDMASTER (8192), BATTLEMASTER (16384),
+# INNKEEPER (64), SPIRITHEALER (2048), SPIRITGUIDE (0 - N/A, assumed covered by general non-targetability), PETITIONER (512)
+# Sum: 8+4+32+16+128+256+1024+4096+8192+16384+64+2048+512 = 32764 (Corrected sum based on typical flags)
+# The provided 49148 includes more or different flags. Let's use the C++ code's default for consistency.
+# The C++ default is: UNIT_NPC_FLAG_VENDOR | UNIT_NPC_FLAG_TRAINER | UNIT_NPC_FLAG_FLIGHTMASTER | UNIT_NPC_FLAG_REPAIRER | UNIT_NPC_FLAG_AUCTIONEER | UNIT_NPC_FLAG_BANKER | UNIT_NPC_FLAG_TABARDDESIGNER | UNIT_NPC_FLAG_STABLEMASTER | UNIT_NPC_FLAG_GUILDMASTER | UNIT_NPC_FLAG_BATTLEMASTER | UNIT_NPC_FLAG_INNKEEPER | UNIT_NPC_FLAG_SPIRITHEALER | UNIT_NPC_FLAG_SPIRITGUIDE | UNIT_NPC_FLAG_PETITIONER
+# These are: 8 | 4 | 32 | 16 | 128 | 256 | 1024 | 4096 | 8192 | 16384 | 64 | 2048 | (Spirit Guide has no specific flag, often just basic) | 512
+# Sum = 32764. The C++ code has this sum.
+TrialOfFinality.CheeringNpcs.ExcludeNpcFlags = 32764
+
+# Interval in milliseconds for the second cheer (if > 0). 0 disables the second cheer.
+# Note: The actual execution of the second cheer is currently logged but not fully implemented due to timer complexities.
+TrialOfFinality.CheeringNpcs.CheerIntervalMs = 2000


### PR DESCRIPTION
This commit implements a cached system for NPC cheering upon Trial of Finality success, significantly improving performance over the previous real-time scanning method.

Key changes:
- NPC cheering eligibility is now determined at server startup/config reload and cached.
- `TrialManager::TriggerCityNpcCheers` now uses this cache, iterating relevant NPCs near players in configured zones.
- Added `CheeringNpcs.CheerIntervalMs` config for a second cheer. The first cheer is performed, and the second is currently logged, deferring full delayed execution pending investigation of core timer mechanisms.
- Updated `mod_trial_of_finality.conf` with all cheering-related configuration options, including comments and appropriate default values.
- Updated `README.md` to document the new cached cheering system, its configuration, and the status of the double cheer feature. Also ensured world announcement configurations are documented.