### PR TITLE
Implement configurable GM exemption from perma-death

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Key configuration options (see the `.conf` file for default values and comments)
 *   `TrialOfFinality.GMDebug.Enable`: (Not currently used to gate GM commands, they are available if module is enabled).
 *   `TrialOfFinality.AnnounceWinners.World.Enable`: (true/false) Enables or disables world announcements upon successful trial completion. Default: `true`.
 *   `TrialOfFinality.AnnounceWinners.World.MessageFormat`: String format for the world announcement. Placeholders: `{group_leader}`, `{player_list}`.
+*   `TrialOfFinality.PermaDeath.ExemptGMs`: (true/false) If `true`, Game Master accounts (security level `SEC_GAMEMASTER` or higher) will not have the perma-death flag set in the database if they fail the trial. This allows GMs to test the mechanics without risk to their characters. Default: `true`.
 
 ### NPC Cheering Settings
 
@@ -116,7 +117,8 @@ Default placeholder pools in `src/mod_trial_of_finality.cpp` are:
     *   They are marked as `permanentlyFailed` for the remainder of this trial instance (internal tracking).
     *   The trial *continues* for any remaining active players. Future waves will scale to the new group size.
     *   Players whose characters have the `is_perma_failed = 1` flag in the database will be kicked from the game upon their next login and will be unable to log into that character again (unless a GM intervenes).
-*   **Group Wipe:** If all currently active players in the trial are downed simultaneously (or disconnect), the trial ends in failure. All players who were "downed" at that point will have the perma-death flag set in the database.
+    *   Note: If `TrialOfFinality.PermaDeath.ExemptGMs` is enabled, Game Master accounts (security level `SEC_GAMEMASTER` or higher) will not have this flag set, allowing them to test without permanent consequences to their characters.
+*   **Group Wipe:** If all currently active players in the trial are downed simultaneously (or disconnect), the trial ends in failure. All players who were "downed" at that point will have the perma-death flag set in the database (unless they are GMs and the exemption is active).
 
 ### 5.4. Trial Success
 *   Successfully defeating all 5 waves while at least one original member remains active (not perma-deathed) results in trial success.
@@ -144,7 +146,7 @@ Access to commands requires `SEC_GAMEMASTER` level.
 *   **.trial test start**
     *   Allows a GM to start a solo test version of the Trial of Finality for themselves.
     *   Bypasses normal group validation. The GM acts as a solo participant.
-    *   The trial mechanics (token, XP disable, teleport, waves, announcer, death rules) apply to the GM. Useful for testing.
+    *   The trial mechanics (token, XP disable, teleport, waves, announcer, death rules) apply to the GM. Note that the outcome regarding perma-death for the GM character is subject to the `TrialOfFinality.PermaDeath.ExemptGMs` configuration setting. Useful for testing.
 
 ## 7. Logging
 

--- a/conf/mod_trial_of_finality.conf
+++ b/conf/mod_trial_of_finality.conf
@@ -20,8 +20,18 @@ Arena.TeleportZ = 30.5
 Arena.TeleportO = 2.3
 # NPC Scaling
 NpcScaling.Mode = "match_highest_level" # Options: "match_highest_level", "custom_scaling_rules" (future)
-# Character Disablement
-DisableCharacter.Method = "custom_flag" # Options: "custom_flag", "player_field_hack" (the honorable kills example)
+
+# --- Perma-Death Settings ---
+# Character Disablement Method - Note: This is informational as the DB flag system is now primary.
+# "custom_flag" historically referred to an Aura, now it's a DB table `character_trial_finality_status`.
+DisableCharacter.Method = "custom_flag"
+
+# If true, Game Masters (Account Security >= SEC_GAMEMASTER) will not have the perma-death flag
+# set in the database when they fail a trial. This allows GMs to test the trial mechanics
+# without risking their characters.
+# Default: true
+TrialOfFinality.PermaDeath.ExemptGMs = true
+
 # GM Debugging
 GMDebug.Enable = false
 


### PR DESCRIPTION
This commit introduces a feature to exempt Game Masters from the perma-death mechanic in the Trial of Finality, configurable via a new setting. This enhances safety for GMs testing the module.

Key changes:
- Added `TrialOfFinality.PermaDeath.ExemptGMs` option to `mod_trial_of_finality.conf` (default: true).
- Modified `TrialManager::FinalizeTrialOutcome` to check this setting and your account security level. If exemption is active and you are a GM (SEC_GAMEMASTER or higher), the perma-death flag is not set in the database for you.
- Updated `README.md` and `docs/testing_guide.md` to document this new configuration option, its behavior, and how it impacts testing procedures for GMs.