### PR TITLE
Make NPC wave pools configurable via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Key configuration options (see the `.conf` file for default values and comments)
 *   `TrialOfFinality.AnnounceWinners.World.MessageFormat`: String format for the world announcement. Placeholders: `{group_leader}`, `{player_list}`.
 *   `TrialOfFinality.PermaDeath.ExemptGMs`: (true/false) If `true`, Game Master accounts (security level `SEC_GAMEMASTER` or higher) will not have the perma-death flag set in the database if they fail the trial. This allows GMs to test the mechanics without risk to their characters. Default: `true`.
 
+### NPC Wave Creature Pools
+These settings allow you to define the pools of creature entry IDs used for each difficulty tier of the trial waves. IDs must be comma-separated. It is crucial to customize these pools with valid creature IDs suitable for your server's balance. The module will log errors and may fail to spawn waves if pools are misconfigured or IDs are invalid.
+
+*   `TrialOfFinality.NpcPools.Easy`: Comma-separated list of creature entry IDs for easy waves (typically waves 1-2). Default: (placeholder IDs from original hardcoded list).
+*   `TrialOfFinality.NpcPools.Medium`: Comma-separated list of creature entry IDs for medium waves (typically waves 3-4). Default: (placeholder IDs from original hardcoded list).
+*   `TrialOfFinality.NpcPools.Hard`: Comma-separated list of creature entry IDs for hard waves (typically wave 5). Default: (placeholder IDs from original hardcoded list).
+
 ### NPC Cheering Settings
 
 These settings control the behavior of NPCs cheering in cities when a trial is successfully completed. This feature uses a cached list of NPCs generated at server startup.
@@ -78,15 +85,11 @@ These settings control the behavior of NPCs cheering in cities when a trial is s
 
 The `AURA_ID_TRIAL_PERMADEATH` (constant `40000` in C++) is no longer the primary mechanism for persistent perma-death. It might be used for immediate in-session effects or visual cues if necessary, but the authoritative source for a character's perma-death status is the `character_trial_finality_status` database table.
 
-### Placeholder Creature ID Pools for Waves
-The module now spawns distinct, randomly selected NPCs for each wave from predefined pools. You **must** ensure the creature IDs listed in these pools in `src/mod_trial_of_finality.cpp` correspond to actual creature templates in your database, or update the pools with valid IDs. Each pool should ideally contain at least 5-10 distinct creature IDs appropriate for the difficulty tier.
-
-Default placeholder pools in `src/mod_trial_of_finality.cpp` are:
-*   `POOL_WAVE_CREATURES_EASY`: Contains IDs like `70001` through `70010`. Intended for Waves 1 & 2.
-*   `POOL_WAVE_CREATURES_MEDIUM`: Contains IDs like `70011` through `70020`. Intended for Waves 3 & 4. These also receive a 20% health boost.
-*   `POOL_WAVE_CREATURES_HARD`: Contains IDs like `70021` through `70030`. Intended for Wave 5. These also receive a 50% health boost.
-
-**It is crucial to customize these creature ID pools with entries suitable for your server's balance and available custom NPCs.**
+### Configurable Creature ID Pools for Waves
+The creature entry IDs for NPCs spawned in each wave are now configurable via the `mod_trial_of_finality.conf` file (see `TrialOfFinality.NpcPools.Easy`, `TrialOfFinality.NpcPools.Medium`, `TrialOfFinality.NpcPools.Hard` options).
+You **must** ensure the creature IDs listed in these configuration settings correspond to actual creature templates in your database.
+The default values in the configuration file are the original placeholder IDs (e.g., 70001-70010 for Easy).
+**It is crucial to customize these creature ID pools with entries suitable for your server's balance and available custom NPCs.** Misconfiguration can lead to errors or empty waves. Each pool should ideally contain at least 5-10 distinct creature IDs appropriate for its difficulty tier to ensure variety.
 
 ## 5. Gameplay Mechanics
 
@@ -155,8 +158,8 @@ Access to commands requires `SEC_GAMEMASTER` level.
 
 ## 8. Developer Notes & Future Considerations
 *   The perma-death mechanism now uses a database flag in the `character_trial_finality_status` table for persistence. This replaces the previous system that relied solely on `AURA_ID_TRIAL_PERMADEATH` (constant `40000`) for long-term status. The aura might still be used for immediate in-session effects or as a visual cue but is cleaned up/secondary to the DB flag.
-*   Creature entries for waves (`70001`-`70030`) are placeholders. Update these in `src/mod_trial_of_finality.cpp` or create these custom NPCs.
+*   Creature entries for waves are now configurable in `mod_trial_of_finality.conf`. Ensure these are updated from the default placeholders (e.g., `70001`-`70030`) to valid creature IDs in your database.
 *   Wave difficulty scaling currently adjusts NPC count and provides a basic health multiplier for later waves. More complex stat scaling or varied NPC abilities per wave could be added.
-*   Consider randomizing NPC types for waves from predefined lists to enhance replayability.
+*   Randomization of NPC types for waves is achieved by shuffling the configured creature ID pools for each spawn event.
 *   World announcements for trial winners have been added (see configuration options).
 ```

--- a/conf/mod_trial_of_finality.conf
+++ b/conf/mod_trial_of_finality.conf
@@ -21,6 +21,18 @@ Arena.TeleportO = 2.3
 # NPC Scaling
 NpcScaling.Mode = "match_highest_level" # Options: "match_highest_level", "custom_scaling_rules" (future)
 
+# --- NPC Wave Creature Pools ---
+# Define the creature entry IDs for each wave difficulty tier.
+# IDs should be comma-separated (e.g., "123,456,789"). Whitespace around IDs is ignored.
+# It is CRUCIAL that these IDs correspond to actual creature templates in your database.
+# The module will check for template existence, but using invalid IDs is not recommended.
+# If a pool is empty or all its configured IDs are invalid, waves for that difficulty may fail to spawn,
+# potentially ending the trial.
+# The default values below are the original placeholder IDs. Customize them for your server.
+TrialOfFinality.NpcPools.Easy = "70001,70002,70003,70004,70005,70006,70007,70008,70009,70010"
+TrialOfFinality.NpcPools.Medium = "70011,70012,70013,70014,70015,70016,70017,70018,70019,70020"
+TrialOfFinality.NpcPools.Hard = "70021,70022,70023,70024,70025,70026,70027,70028,70029,70030"
+
 # --- Perma-Death Settings ---
 # Character Disablement Method - Note: This is informational as the DB flag system is now primary.
 # "custom_flag" historically referred to an Aura, now it's a DB table `character_trial_finality_status`.


### PR DESCRIPTION
This commit refactors the NPC wave pool definitions, moving them from hardcoded C++ vectors to configurable, comma-separated strings in `mod_trial_of_finality.conf`. This significantly improves usability and customization for server administrators.

Key changes:
- Removed hardcoded `POOL_WAVE_CREATURES_EASY/MEDIUM/HARD` constants in C++.
- Introduced new global `std::vector<uint32>` variables (`NpcPoolEasy`, `NpcPoolMedium`, `NpcPoolHard`) to store creature IDs for each pool.
- Implemented parsing logic in `ModServerScript::OnConfigLoad` to load and validate these pools from new `.conf` options:
    - `TrialOfFinality.NpcPools.Easy`
    - `TrialOfFinality.NpcPools.Medium`
    - `TrialOfFinality.NpcPools.Hard` The parser includes error handling for malformed entries and checks for creature template existence.
- Updated `TrialManager::SpawnActualWave` to use these dynamically loaded pools, including logic to handle empty or insufficiently sized pools.
- Added the new options to `mod_trial_of_finality.conf` with comments and default placeholder values.
- Updated `README.md` and `docs/testing_guide.md` to reflect these changes, explaining the new configuration method and updating testing procedures.