### PR TITLE
Feat: Implement Trial Confirmation System

### DIFF
--- a/conf/mod_trial_of_finality.conf
+++ b/conf/mod_trial_of_finality.conf
@@ -44,6 +44,24 @@ DisableCharacter.Method = "custom_flag"
 # Default: true
 TrialOfFinality.PermaDeath.ExemptGMs = true
 
+# --- Trial Confirmation Settings ---
+# Enable/disable the trial start confirmation system for group members.
+# If true, members (excluding the leader) must type '/trialconfirm yes' to join.
+# If false, the trial starts immediately for all group members once initiated by the leader.
+# Default: true
+TrialOfFinality.Confirmation.Enable = true
+
+# Number of seconds group members have to confirm their participation.
+# Default: 60
+TrialOfFinality.Confirmation.TimeoutSeconds = 60
+
+# Mode for required confirmations.
+# Options: "all" (all prompted members must accept).
+# Future options might include "majority", "leader_plus_one".
+# Currently, only "all" is supported by the module.
+# Default: "all"
+TrialOfFinality.Confirmation.RequiredMode = "all"
+
 # GM Debugging
 GMDebug.Enable = false
 


### PR DESCRIPTION
This commit introduces a confirmation system for starting the Trial of Finality. Group members (excluding the leader) must now explicitly accept participation via a chat command before the trial begins. This prevents unwilling players from being forced into a perma-death scenario.

Key changes:
- New chat commands for players: `/trialconfirm yes` (alias `/tc yes`) and `/trialconfirm no` (alias `/tc no`).
- `TrialManager::InitiateTrial` now creates a pending confirmation state and sends prompts to group members.
- `TrialManager::HandleTrialConfirmation` processes player responses. If all accept, the trial starts; if any decline, it's aborted.
- `TrialManager::UpdatePendingConfirmations` (called via `ModServerScript::OnUpdate`) handles timeouts for confirmations.
- `TrialManager::StartConfirmedTrial` centralizes the actual trial activation logic.
- New configuration options in `mod_trial_of_finality.conf`:
    - `TrialOfFinality.Confirmation.Enable` (default: true)
    - `TrialOfFinality.Confirmation.TimeoutSeconds` (default: 60)
    - `TrialOfFinality.Confirmation.RequiredMode` (default: "all", currently only "all" is supported)
- Updated `README.md`, `docs/DEVELOPER_GUIDE.md`, and `docs/testing_guide.md` to reflect the new system, commands, configurations, and testing procedures.