### PR TITLE
Fix(build): Update include paths to resolve build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,7 @@ set(MODULE_SOURCES
 add_library(${MODULE_NAME} MODULE ${MODULE_SOURCES})
 
 # Include AzerothCore directories
-target_include_directories(${MODULE_NAME} PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/server
-    ${CMAKE_SOURCE_DIR}/dep/g3dlite/include
-    ${CMAKE_SOURCE_DIR}/dep/gsoap
-    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Include
-    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Detour/Include
-    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/DetourTileCache/Include
-    ${CMAKE_BINARY_DIR}
-)
+target_include_directories(${MODULE_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
 
 # Link against AzerothCore targets
 target_link_libraries(${MODULE_NAME} PRIVATE game shared)

--- a/src/mod_trial_of_finality.cpp
+++ b/src/mod_trial_of_finality.cpp
@@ -1,22 +1,31 @@
 // AzerothCore includes
-#include "AreaTriggerScript.h"
-#include "Chat.h"
-#include "Config.h"
-#include "Creature.h"
-#include "CreatureAI.h"
-#include "GossipDef.h"
-#include "game/Maps/MapMgr.h"
-#include "Group.h"
-#include "Item.h"
-#include "Map.h"
-#include "ObjectMgr.h"
-#include "Player.h"
-#include "CreatureScript.h"
-#include "ScriptMgr.h"
-#include "WorldSession.h"
-#include "Log.h"
-#include "ChatCommand.h"
-#include "World.h"
+#include "src/server/game/AI/ScriptedAI/ScriptedCreature.h"
+#include "src/server/game/Chat/Chat.h"
+#include "src/server/game/Config/Config.h"
+#include "src/server/game/Entities/Creature/Creature.h"
+#include "src/server/game/AI/CreatureAI.h"
+#include "src/server/game/Gossip/GossipDef.h"
+#include "src/server/game/Maps/MapMgr.h"
+#include "src/server/game/Entities/Group/Group.h"
+#include "src/server/game/Entities/Item/Item.h"
+#include "src/server/game/Maps/Map.h"
+#include "src/server/game/Objects/ObjectMgr.h"
+#include "src/server/game/Entities/Player/Player.h"
+#include "src/server/game/Scripting/ScriptMgr.h"
+#include "src/server/game/Server/WorldSession.h"
+#include "src/common/Logging/Log.h"
+#include "src/server/game/Chat/ChatCommand.h"
+#include "src/server/game/World/World.h"
+#include "src/server/game/Objects/ObjectAccessor.h"
+#include "src/server/game/DBC/DBCStores.h"
+#include "src/server/database/DatabaseEnv.h"
+#include "src/common/Utilities/ObjectGuid.h"
+#include "src/server/game/Cache/CharacterCache.h"
+#include "src/server/game/Scripting/ScriptDefines/InstanceScript.h"
+#include "src/server/scripts/Scripting/ScriptedGossip.h"
+#include "src/server/game/Scripting/ScriptDefines/CreatureScript.h"
+#include "src/server/game/Scripting/ScriptDefines/AreaTriggerScript.h"
+
 
 #include <time.h>
 #include <set>
@@ -28,14 +37,6 @@
 #include <random>
 #include <chrono>
 #include <string>
-
-#include "ObjectAccessor.h"
-#include "Player.h"
-#include "DBCStores.h"
-#include "DatabaseEnv.h"
-#include "ObjectGuid.h"
-#include "CharacterCache.h"
-#include "InstanceScript.h"
 
 // Module specific namespace
 namespace ModTrialOfFinality


### PR DESCRIPTION
The module was failing to build due to outdated include paths that did not match the modern AzerothCore source structure.

This commit resolves the issue by:
1.  Correcting the `CMakeLists.txt` to use the standard include directory configuration for a modern AzerothCore module.
2.  Updating all `#include` directives in `src/mod_trial_of_finality.cpp` to use the correct paths relative to the AzerothCore source root.